### PR TITLE
[agent] Installer no-sudo fallback + quieter `envx auth`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -158,18 +158,22 @@ unpack() {
   return 1
 }
 
-elevate_priv() {
+try_elevate_priv() {
   if ! has sudo; then
     error 'Could not find the command "sudo", needed to get permissions for install.'
     info "If you are on Windows, please run your shell as an administrator, then"
     info "rerun this script. Otherwise, please run this script as root, or install"
     info "sudo."
-    exit 1
+    return 1
   fi
   if ! sudo -v; then
     error "Superuser not granted, aborting installation"
-    exit 1
+    return 1
   fi
+}
+
+elevate_priv() {
+  try_elevate_priv || exit 1
 }
 
 install() {
@@ -183,9 +187,21 @@ install() {
     msg="Installing envx, please wait…"
   else
     warn "Escalated permissions are required to install to ${BIN_DIR}"
-    elevate_priv
-    sudo="sudo"
-    msg="Installing envx as root, please wait…"
+    if [ "${BIN_DIR_EXPLICIT}" = 1 ]; then
+      elevate_priv
+      sudo="sudo"
+      msg="Installing envx as root, please wait…"
+    elif try_elevate_priv; then
+      sudo="sudo"
+      msg="Installing envx as root, please wait…"
+    else
+      warn "Couldn't write to ${BIN_DIR} without sudo; installing to ${HOME}/.local/bin instead"
+      BIN_DIR="${HOME}/.local/bin"
+      mkdir -p "${BIN_DIR}"
+      check_bin_dir "${BIN_DIR}"
+      sudo=""
+      msg="Installing envx, please wait…"
+    fi
   fi
   info "$msg"
 
@@ -337,6 +353,7 @@ is_build_available() {
 }
 UNINSTALL=0
 HELP=0
+BIN_DIR_EXPLICIT=0
 
 CARGOTOML="$(curl -fsSL https://raw.githubusercontent.com/env-store/rusty-cli/master/Cargo.toml)"
 ALL_VERSIONS="$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' <<EOH
@@ -361,6 +378,9 @@ fi
 
 if [ -z "${ENVX_BIN_DIR-}" ]; then
   BIN_DIR=/usr/local/bin
+else
+  BIN_DIR="${ENVX_BIN_DIR}"
+  BIN_DIR_EXPLICIT=1
 fi
 
 if [ -z "${ENVX_ARCH-}" ]; then
@@ -380,6 +400,7 @@ while [ "$#" -gt 0 ]; do
     ;;
   -b | --bin-dir)
     BIN_DIR="$2"
+    BIN_DIR_EXPLICIT=1
     shift 2
     ;;
   -a | --arch)
@@ -413,6 +434,7 @@ while [ "$#" -gt 0 ]; do
     ;;
   -b=* | --bin-dir=*)
     BIN_DIR="${1#*=}"
+    BIN_DIR_EXPLICIT=1
     shift 1
     ;;
   -a=* | --arch=*)

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -14,6 +14,7 @@ pub struct Args {
 pub async fn command(args: Args, config: &mut Config) -> anyhow::Result<()> {
     let key = config.primary_key()?;
     let password = config.primary_key_password()?;
+    let fingerprint = key.fingerprint[..8].to_string();
 
     if key.uuid.is_none() {
         bail!("Key does not have a UUID, try `envx upload`");
@@ -24,7 +25,9 @@ pub async fn command(args: Args, config: &mut Config) -> anyhow::Result<()> {
     let client = reqwest::Client::new();
     let auth_token = key.auth_token()?;
 
-    println!("auth token:\n{}", auth_token.signature);
+    if args.debug {
+        println!("auth token:\n{}", auth_token.signature);
+    }
 
     let url = format!("{}test-auth", api_url());
 
@@ -45,12 +48,12 @@ pub async fn command(args: Args, config: &mut Config) -> anyhow::Result<()> {
     let status = res.status();
 
     if status.is_success() {
-        println!("success");
-        // print the text response
-
         let text = res.text().await?;
 
-        println!("{}", text);
+        println!("{} fingerprint: {}", "✓ authenticated".green(), fingerprint);
+        if args.debug {
+            println!("{}", text);
+        }
     } else {
         println!("status: {}", status);
         bail!("failed to auth")


### PR DESCRIPTION
## [agent] Installer no-sudo fallback + quieter `envx auth`

Two UX fixes surfaced while onboarding envx on a fresh macOS box.

### `install.sh` — fall back to `~/.local/bin` instead of aborting
`curl -fsSL https://get.envx.sh | sh` on a machine where `/usr/local/bin` needs sudo but there's no TTY (or sudo isn't installed) aborted with `Superuser not granted, aborting installation`, even though a no-sudo install to `~/.local/bin` is possible.

Now: `elevate_priv` is split into a non-fatal `try_elevate_priv`. When the target dir isn't writable:
- **Explicit** `--bin-dir` / `ENVX_BIN_DIR` → unchanged (fatal sudo path — you asked for that dir).
- **Default** `/usr/local/bin` + sudo unavailable/denied → falls back to `$HOME/.local/bin` (`mkdir -p`, PATH warning) and installs there instead of dying.

### `envx auth` — concise output
`auth` unconditionally printed the raw PGP `auth token` signature and then `success` + the raw server response. Now it prints a single `✓ authenticated  fingerprint: <fp>` line; the token and raw response are shown only under `--debug`. Exit-code contract is unchanged (0 on success, error on failure).

Verified: `cargo fmt --check` clean, `cargo build` compiles, `cargo clippy` runs; installer fallback path exercised manually.

Co-Authored-By: GPT-5.5 <noreply@openai.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
